### PR TITLE
Cleanup. Removed not needed vendor prefixes.

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -1,110 +1,109 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>PiRo</title>
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-  <link href="stylesheets/reset.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/grids.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/spaces.css" media="screen" rel="stylesheet" type="text/css" />  
-  <link href="stylesheets/group-headers.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/group-buttons.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/group-forms.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/layout.css" media="screen" rel="stylesheet" type="text/css" />
-  <link href="stylesheets/library.css" media="screen" rel="stylesheet" type="text/css" />
-  
-  <!-- chosen -->
-  <link href="stylesheets/chosen/chosen.css" media="screen" rel="stylesheet" type="text/css" />
-  <!-- jquery ui datepicker -->
-  <link href="stylesheets/jquery_ui/datepicker.css" media="screen" rel="stylesheet" type="text/css" />
-</head>
+  <head>
+    <title>PiRo</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <link href="stylesheets/reset.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/grids.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/spaces.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/group-headers.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/group-buttons.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/group-forms.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/layout.css" media="screen" rel="stylesheet" type="text/css" />
+    <link href="stylesheets/library.css" media="screen" rel="stylesheet" type="text/css" />
+
+    <!-- chosen -->
+    <link href="stylesheets/chosen/chosen.css" media="screen" rel="stylesheet" type="text/css" />
+    <!-- jquery ui datepicker -->
+    <link href="stylesheets/jquery_ui/datepicker.css" media="screen" rel="stylesheet" type="text/css" />
+  </head>
 <body>
-  
   <div id="mainPage" class="outer page">
     <!-- main screen -->
     <div id="leftPanel" class="unit size1of2">
-      <!-- panel -->      
-      
+      <!-- panel -->
+
       <div id="storiesTabs">
-      	<div id="ownerStories" class="tabs_content_block">
-      	  <ul class="nav outer">
-        		<li class="owner tab size1of3"><a id="currentTabLabel" href="#currentTab">Current</a></li>
-        		<li class="owner tab size1of3"><a id="doneTabLabel" href="#doneTab">Done</a></li>
-        		<li class="owner tab size1of3"><a id="iceboxTabLabel" href="#iceboxTab">IceBox</a></li>
-        	</ul>
-      	  <!-- tabs content -->
-        	<div id="currentTab" class="tabs_content data-holder">
-        	  <ul id="currentStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-        	<div id="doneTab" class="tabs_content data-holder">
-        		<ul id="doneStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-        	<div id="iceboxTab" class="tabs_content data-holder">
-        		<ul id="iceboxStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-      	</div>	
-      	
-      	<!-- requester tabs content -->
-      	<div id="requesterStories" class="tabs_content_block">
-      	  <ul class="nav outer">
-        		<li class="requester tab size1of3"><a id="currentRequesterTabLabel" href="#currentRequesterTab">Current</a></li>
-        		<li class="requester tab size1of3"><a id="doneRequesterTabLabel" href="#doneRequesterTab">Done</a></li>
-        		<li class="requester tab size1of3"><a id="iceboxRequesterTabLabel" href="#iceboxRequesterTab">IceBox</a></li>
-        	</ul>
-        	<div id="currentRequesterTab" class="tabs_content data-holder">
-        	  <ul id="currentRequesterStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-        	<div id="doneRequesterTab" class="tabs_content data-holder">
-        		<ul id="doneRequesterStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-        	<div id="iceboxRequesterTab" class="tabs_content data-holder">
-        		<ul id="iceboxRequesterStoriesList" class="projects_stories_list">
-        	  </ul>
-        	</div>
-      	</div>
-      
+        <div id="ownerStories" class="tabs_content_block">
+          <ul class="nav outer">
+            <li class="owner tab size1of3"><a id="currentTabLabel" href="#currentTab">Current</a></li>
+            <li class="owner tab size1of3"><a id="doneTabLabel" href="#doneTab">Done</a></li>
+            <li class="owner tab size1of3"><a id="iceboxTabLabel" href="#iceboxTab">IceBox</a></li>
+          </ul>
+          <!-- tabs content -->
+          <div id="currentTab" class="tabs_content data-holder">
+            <ul id="currentStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+          <div id="doneTab" class="tabs_content data-holder">
+            <ul id="doneStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+          <div id="iceboxTab" class="tabs_content data-holder">
+            <ul id="iceboxStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+        </div>
+
+        <!-- requester tabs content -->
+        <div id="requesterStories" class="tabs_content_block">
+          <ul class="nav outer">
+            <li class="requester tab size1of3"><a id="currentRequesterTabLabel" href="#currentRequesterTab">Current</a></li>
+            <li class="requester tab size1of3"><a id="doneRequesterTabLabel" href="#doneRequesterTab">Done</a></li>
+            <li class="requester tab size1of3"><a id="iceboxRequesterTabLabel" href="#iceboxRequesterTab">IceBox</a></li>
+          </ul>
+          <div id="currentRequesterTab" class="tabs_content data-holder">
+            <ul id="currentRequesterStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+          <div id="doneRequesterTab" class="tabs_content data-holder">
+            <ul id="doneRequesterStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+          <div id="iceboxRequesterTab" class="tabs_content data-holder">
+            <ul id="iceboxRequesterStoriesList" class="projects_stories_list">
+            </ul>
+          </div>
+        </div>
+
         <div class="footer">
           <div class="outer">
             <div class="unit size1of2 ptxs">
               <div id="changeAccountBox" class="unit mls">
                 <!-- <label class="h4">Account:</label> -->
-            	   <select id="changeAccount"></select>
-            	</div>
-            	<div id="selecterStoriesBox" class="unit-right mrs">
-            	  <span class="switcher">
-            	    <a class="selecter_stories_type" href="#" data-value="owner">Owner</a>
-              	  <a class="selecter_stories_type" href="#" data-value="requester">Requester</a>
-            	  </span>            	   
-            	 </div>
+                 <select id="changeAccount"></select>
+              </div>
+              <div id="selecterStoriesBox" class="unit-right mrs">
+                <span class="switcher">
+                  <a class="selecter_stories_type" href="#" data-value="owner">Owner</a>
+                  <a class="selecter_stories_type" href="#" data-value="requester">Requester</a>
+                </span>
+               </div>
             </div> <!-- unit size1of2 -->
             <div class="unit size1of2">
               <div class="footer-sep outer ptxs">
                 <div class="unit mls">
                   <a id="settingsLink" href="#" class="button default tiny settings-btn"><span>Settings</span></a>
-              	</div>
-              	<div class="unit-right mrs">
-              	   <span class="h4 neutral powered">Brought to you by <a href="http://railsware.com/?utm_source=piro.railsware.com&utm_medium=cpc&utm_term=rw%2Bproduct&utm_campaign=piro" target="_blank"><img src="images/rw.png" alt="Railsware" /></a></span>
-              	 </div>
+                </div>
+                <div class="unit-right mrs">
+                   <span class="h4 neutral powered">Brought to you by <a href="http://railsware.com/?utm_source=piro.railsware.com&utm_medium=cpc&utm_term=rw%2Bproduct&utm_campaign=piro" target="_blank"><img src="images/rw.png" alt="Railsware" /></a></span>
+                 </div>
               </div> <!-- empty -->
-              
+
             </div> <!-- unit size1of2 -->
-          </div> <!-- outer -->          
-        </div> <!-- footer -->      	
-      	
+          </div> <!-- outer -->
+        </div> <!-- footer -->
+
       </div>
     </div>
-    
+
     <!-- main story info and notifications -->
     <div id="rightPanel" class="unit size1of2">
       <div class="story-header outer">
         <div class="unit size4of5">
-          <div class="plm">          
+          <div class="plm">
             <input id="searchStories" type="search" placeholder="Search stories" />
-          </div> <!-- plm -->          
+          </div> <!-- plm -->
         </div> <!-- unit -->
         <div class="unit-right size1of5 txt-right">
           <span id="loaderSpinner"></span>
@@ -115,14 +114,14 @@
       <div id="storyInfo" class="data-holder grey-box pam"></div>
       <div id="addStoryView" class="data-holder grey-box pam"></div>
     </div>
-    
+
   </div>
-  
+
   <div id="loginPage" class="pal">
     <div class="txt-center mbm">
       <img id="loginLogo" src="images/logo.png" alt="PiRo" />
     </div> <!-- txt-center -->
-    
+
     <span class="switcher wide mbs">
       <a id="pivotalBaseAuthLink" href="#" class="login_switcher_link active">Login with Email</a>
       <a id="pivotalTokenAuthLink" href="#" class="login_switcher_link">Login with Token</a>
@@ -148,7 +147,7 @@
       </div> <!-- pvs -->
     </div>
   </div>
-  
+
   <!-- templates -->
   <script id="spinner_template" type="text/x-mustache-template">
     {{#is_loading}}
@@ -160,7 +159,7 @@
       </a>
     {{/is_loading}}
   </script>
-  
+
   <script id="project_cell_template" type="text/x-mustache-template">
     <li class="project_{{id}} project_cell{{#view_conditions}}{{#hide_project_cell}} hide-project{{/hide_project_cell}}{{/view_conditions}}" data-project-id="{{id}}">
 
@@ -169,21 +168,21 @@
         <span class="dbclick_toggle_project project-title">({{count_of_stories}}) {{name}}</span> 
         <span class="sort_project unit-right" title="Drag to sort projects" data-project-id="{{id}}"></span>
       </div>
-      
+
       <ul data-project-id="{{id}}" {{#is_requested_by_me}}data-requested="true"{{/is_requested_by_me}} class="list stories">
         {{#stories}}
           <li class="story_info story_{{id}} {{box_class}}-box outer" data-story-id="{{id}}">
             <div class="unit"><span class="{{story_type}}-icon"></span></div>
             <div class="unit-right"><span class="status">{{current_state}}</span></div>
-            <div class="story-name">{{name}}</div>                  
+            <div class="story-name">{{name}}</div>
           </li>
         {{/stories}}
       </ul>
     </li>
   </script>
-  
+
   <script id="story_info_template" type="text/x-mustache-template">
-    
+
     <div class="outer story-details-header">
       <div class="unit size1of2">
         <div class="outer clippy-holder mbxs">
@@ -195,7 +194,7 @@
           <div class="clippy-box"><div id="clippyUrl{{id}}"></div></div>
         </div>
       </div>
-      <div class="unit size1of2 txt-right">        
+      <div class="unit size1of2 txt-right">
         <div class="change_story_box">
           <div class="main options">
           {{#need_estimate}}
@@ -209,13 +208,13 @@
               </select>
             </div>
           {{/need_estimate}}
-          
+
           {{^need_estimate}}
             <div class="mbxs">
               <span class="label">Estimate: </span> <div class="value"><span class="status block txt-center">{{estimate_text}}</span></div>
             </div>
           {{/need_estimate}}
-          
+
           {{^unestimated_feature}}
             <div>
               <span class="label">Status: </span>
@@ -236,13 +235,13 @@
             </div>
 
           {{/unestimated_feature}}
-            
+
           {{#unestimated_feature}}
             <div>
               <span class="label">Status: </span> <div class="value"><span class="status status block txt-center">{{current_state}}</span></div>
             </div>
           {{/unestimated_feature}}
-            
+
           </div>
           <div class="loader">
             <img src="images/spinner3.gif" alt="loading..." title="loading..." />
@@ -251,7 +250,6 @@
       </div>
     </div>
 
-    
     <h1 class="mts mbxs story_title {{story_type}}-icon-title">{{name}}</h1>
     <div class="mbm">
         <div><span class="pale">Requested by:</span> {{requested_by.person.name}}</div>
@@ -260,7 +258,7 @@
           <div><span class="pale">Deadline:</span> {{deadline}}</div>
         {{/deadline}}
     </div>
-    
+
     <h2 class="mbs">Description</h2>
     <div class="story_description prs" data-description="{{description}}">{{description}}</div>
     {{#labels_html}}
@@ -273,7 +271,7 @@
         <a href="#" class="filter_all_tasks filter_tasks active">all</a>
         <a href="#" class="filter_completed_tasks filter_tasks">completed</a>
         <a href="#" class="filter_uncompleted_tasks filter_tasks">uncompleted</a>
-      </span>      
+      </span>
     </h2>
     {{#has_tasks}}
       <ul class="list mbm mrs tasks tasks_list">
@@ -327,7 +325,7 @@
                 <!-- <div class="clippy-box">
                   <div id="attachment_{{id}}" class="attachment_clippy" data-attachment-url="{{url}}"></div>
                 </div> -->
-              </div>              
+              </div>
           </li>
         {{/attachments}}
       </ul>
@@ -375,7 +373,7 @@
       </div>
     </div>
   </script>
-  
+
   <script id="add_story_template" type="text/x-mustache-template">
     <div class="add_story_box">
       <div class="main form">
@@ -416,7 +414,7 @@
             </div>
           </div>
         </div>
-        
+
         <div class="outer mbs">
           <div class="unit size1of2">
             <div class="prs">
@@ -439,7 +437,7 @@
         </div>
         <div class="mbm">
           <label>Labels: (<span class="h4 pale">type labels separated by comma</span>)</label>
-          <input class="add_story_labels" type="text" />          
+          <input class="add_story_labels" type="text" />
         </div>
         <div class="mbs">
           <input class="add_story_button button success" type="button" value="Add" />
@@ -452,7 +450,7 @@
       </div>
     </div>
   </script>
-  
+
   <script id="add_story_result_template" type="text/x-mustache-template">
     <div class="h1 mbm"><span class="done">Story successfully added</span></div>
     <div class="mbs mhl"><strong>{{name}}</strong></div>
@@ -461,7 +459,7 @@
       <a class="add_more_stories button primary" href="#">Add one more story</a><span class="mhs">or</span><a class="add_story_close" href="#">Close</a>
     </div>
   </script>
-  
+
   <!-- vendors scripts -->
   <script src="javascripts/vendors/jquery-1.7.1.min.js" type="text/javascript"></script>
   <script src="javascripts/vendors/jquery-ui-1.8.16.custom.min.js" type="text/javascript"></script>
@@ -475,6 +473,6 @@
   <script src="javascripts/pivotal_rocket_storage.js" type="text/javascript"></script>
   <script src="javascripts/pivotal_api_lib.js" type="text/javascript"></script>
   <script src="javascripts/pivotal_rocket_popup.js" type="text/javascript"></script>
-  
+
 </body>
 </html>

--- a/stylesheets/group-buttons.css
+++ b/stylesheets/group-buttons.css
@@ -3,10 +3,9 @@
     padding: 3px 10px;
     text-decoration: none;
     border-radius: 4px;
-    box-shadow: 0 1px 0 rgba(255,255,255, 0.4) inset, 
+    box-shadow: 0 1px 0 rgba(255,255,255, 0.4) inset,
                 0 1px 1px rgba(80,80,80, 0.3),
                 0 0 0 2px rgba(80,80,80, 0.1);
-    background-image: -moz-linear-gradient(top, rgba(255,255,255,0.32) 0%, rgba(255,255,255,0) 100%); /* FF3.6+ */
     background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0.32)), color-stop(100%,rgba(255,255,255,0))); /* Chrome,Safari4+ */
     background-image: -webkit-linear-gradient(top, rgba(255,255,255,0.32) 0%,rgba(255,255,255,0) 100%); /* Chrome10+,Safari5.1+ */
     background-image: linear-gradient(top, rgba(255,255,255,0.32) 0%,rgba(255,255,255,0) 100%); /* W3C */

--- a/stylesheets/group-forms.css
+++ b/stylesheets/group-forms.css
@@ -9,8 +9,6 @@ textarea {
     border-radius: 3px;
     border: 1px solid #9c9c9c;
     font-family: arial, sans-serif;
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
 }
 
@@ -23,7 +21,7 @@ textarea:focus {
 }
 
 select {
-    padding: 2px;    
+    padding: 2px;
     vertical-align: middle;
 }
 

--- a/stylesheets/group-headers.css
+++ b/stylesheets/group-headers.css
@@ -1,25 +1,31 @@
-h1, .h1 {font-size: 18px;}
-h2 {
-    font-size: 13px; 
-    font-weight: bold; 
-    background-color: rgba(100,100,100, 0.2); 
-    padding: 3px 10px 3px 20px; 
-    margin-left: -20px;
-    border-top: 1px solid rgba(25,25,25, 0.1);
-    box-shadow: 0 1px 0 rgba(255,255,255, 0.4); 
-    border-radius: 0 16px 16px 0;
-    text-shadow: 0 1px 0 rgba(255,255,255, 0.7);
-    
-    background: -moz-linear-gradient(left,  rgba(124,124,124,0.1) 0%, rgba(186,186,186,0.65) 100%);
-    background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(124,124,124,0.1)), color-stop(100%,rgba(186,186,186,0.65)));
-    background: -webkit-linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
-    background: -o-linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
-    background: -ms-linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
-    background: linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1a7c7c7c', endColorstr='#a6bababa',GradientType=1 );
-    
+h1, .h1 {
+    font-size: 18px;
 }
 
-.h2 {font-size: 14px;}
-h3, .h3 {font-size: 12px;}
-h4, .h4 {font-size: 11px;}
+h2 {
+    font-size: 13px;
+    font-weight: bold;
+    background-color: rgba(100,100,100, 0.2);
+    padding: 3px 10px 3px 20px;
+    margin-left: -20px;
+    border-top: 1px solid rgba(25,25,25, 0.1);
+    box-shadow: 0 1px 0 rgba(255,255,255, 0.4);
+    border-radius: 0 16px 16px 0;
+    text-shadow: 0 1px 0 rgba(255,255,255, 0.7);
+
+    background: -webkit-gradient(linear, left top, right top, color-stop(0%,rgba(124,124,124,0.1)), color-stop(100%,rgba(186,186,186,0.65)));
+    background: -webkit-linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
+    background: linear-gradient(left,  rgba(124,124,124,0.1) 0%,rgba(186,186,186,0.65) 100%);
+}
+
+.h2 {
+    font-size: 14px;
+}
+
+h3, .h3 {
+    font-size: 12px;
+}
+
+h4, .h4 {
+    font-size: 11px;
+}

--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -136,6 +136,13 @@ body {
     background: linear-gradient(top,  rgba(125,126,125,1) 0%,rgba(14,14,14,1) 100%);
 }
 
+.nav a:hover {
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0.25)), color-stop(100%,rgba(255,255,255,0)));
+    background: -webkit-linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
+    background: linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
+    color: #fff;
+}
+
 .nav li:first-child a {
     border-radius: 5px 0 0 0;
     border-left: 0;
@@ -145,9 +152,7 @@ body {
     border-right: 1px solid #222;
 }
 
-.ui-tabs-nav { margin: 0; padding: 0; }
-
-.ui-tabs-selected a {
+.nav .ui-tabs-selected a {
     color: #000;
     font-weight: bold;
     text-shadow: 0 1px 0 rgba(255,255,255, 0.5);
@@ -158,44 +163,38 @@ body {
     background: linear-gradient(top,  rgba(68,68,68,1) 0%,rgba(125,126,125,1) 100%);
 }
 
-.ui-tabs-nav a:hover {
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0.25)), color-stop(100%,rgba(255,255,255,0)));
-    background: -webkit-linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
-    background: linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
-}
-
-.ui-tabs-selected a#currentRequesterTabLabel,
-.ui-tabs-selected a#currentTabLabel {
+.nav .ui-tabs-selected a#currentRequesterTabLabel,
+.nav .ui-tabs-selected a#currentTabLabel {
     background: rgb(241,231,103);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(241,231,103,1)), color-stop(100%,rgba(254,182,69,1)));
     background: -webkit-linear-gradient(top,  rgba(241,231,103,1) 0%,rgba(254,182,69,1) 100%);
     background: linear-gradient(top,  rgba(241,231,103,1) 0%,rgba(254,182,69,1) 100%);
 }
 
-.ui-tabs-selected a#doneRequesterTabLabel,
-.ui-tabs-selected a#doneTabLabel {
+.nav .ui-tabs-selected a#doneRequesterTabLabel,
+.nav .ui-tabs-selected a#doneTabLabel {
     background: rgb(198,226,113);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(198,226,113,1)), color-stop(100%,rgba(143,196,0,1)));
     background: -webkit-linear-gradient(top,  rgba(198,226,113,1) 0%,rgba(143,196,0,1) 100%);
     background: linear-gradient(top,  rgba(198,226,113,1) 0%,rgba(143,196,0,1) 100%);
 }
 
-.ui-tabs-selected a#iceboxRequesterTabLabel,
-.ui-tabs-selected a#iceboxTabLabel {
+.nav .ui-tabs-selected a#iceboxRequesterTabLabel,
+.nav .ui-tabs-selected a#iceboxTabLabel {
     background: rgb(135,224,253);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(135,224,253,1)), color-stop(40%,rgba(83,203,241,1)), color-stop(100%,rgba(5,171,224,1)));
     background: -webkit-linear-gradient(top,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
     background: linear-gradient(top,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
 }
 
-.ui-tabs-selected a,
-.ui-tabs-nav .ui-state-disabled a,
-.ui-tabs-nav .ui-state-processing a {
+.nav .ui-tabs-selected a,
+.nav .ui-tabs-nav .ui-state-disabled a,
+.nav .ui-tabs-nav .ui-state-processing a {
     cursor: text;
 }
 
-.ui-tabs-nav a,
-.ui-tabs-collapsible .ui-tabs-selected a {
+.nav .ui-tabs-nav a,
+.nav .ui-tabs-collapsible .ui-tabs-selected a {
   cursor: pointer;
 } /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
 

--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -118,7 +118,7 @@ body {
     float: left;
 }
 
-.nav li a {
+.nav a {
     display: block;
     height: 29px;
     line-height: 30px;
@@ -146,6 +146,7 @@ body {
 }
 
 .ui-tabs-nav { margin: 0; padding: 0; }
+
 .ui-tabs-selected a {
     color: #000;
     font-weight: bold;

--- a/stylesheets/layout.css
+++ b/stylesheets/layout.css
@@ -17,8 +17,6 @@ body {
 }
 
 .data-holder {
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
     box-sizing: border-box;
     position: absolute;
     width: 380px;
@@ -69,7 +67,6 @@ body {
     border-radius: 0 0 5px 5px;
     box-shadow: 0 -1px 7px rgba(0,0,0, 0.1);
     background: rgb(238,238,238);
-    background: -moz-linear-gradient(top,  rgba(238,238,238,1) 0%, rgba(204,204,204,1) 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(238,238,238,1)), color-stop(100%,rgba(204,204,204,1)));
     background: -webkit-linear-gradient(top,  rgba(238,238,238,1) 0%,rgba(204,204,204,1) 100%);
     background: linear-gradient(top,  rgba(238,238,238,1) 0%,rgba(204,204,204,1) 100%);
@@ -93,7 +90,6 @@ body {
     height: 30px;
     border-radius: 0 5px 0 0;
     background: rgb(125,126,125);
-    background: -moz-linear-gradient(top,  rgba(125,126,125,1) 0%, rgba(14,14,14,1) 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(125,126,125,1)), color-stop(100%,rgba(14,14,14,1)));
     background: -webkit-linear-gradient(top,  rgba(125,126,125,1) 0%,rgba(14,14,14,1) 100%);
     background: linear-gradient(top,  rgba(125,126,125,1) 0%,rgba(14,14,14,1) 100%);
@@ -113,7 +109,6 @@ body {
     border-radius: 5px 0 0 0;
     border-bottom: 1px solid #333;
     background: rgb(125,126,125);
-    background: -moz-linear-gradient(top,  rgba(125,126,125,1) 0%, rgba(14,14,14,1) 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(125,126,125,1)), color-stop(100%,rgba(14,14,14,1)));
     background: -webkit-linear-gradient(top,  rgba(125,126,125,1) 0%,rgba(14,14,14,1) 100%);
     background: linear-gradient(top,  rgba(125,126,125,1) 0%,rgba(14,14,14,1) 100%);
@@ -150,8 +145,8 @@ body {
     border-right: 1px solid #222;
 }
 
-.ui-tabs .ui-tabs-nav { margin: 0; padding: 0; }
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a { 
+.ui-tabs-nav { margin: 0; padding: 0; }
+.ui-tabs-selected a {
     color: #000;
     font-weight: bold;
     text-shadow: 0 1px 0 rgba(255,255,255, 0.5);
@@ -159,62 +154,70 @@ body {
     background: rgb(68,68,68);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(68,68,68,1)), color-stop(100%,rgba(125,126,125,1)));
     background: -webkit-linear-gradient(top,  rgba(68,68,68,1) 0%,rgba(125,126,125,1) 100%);
-    background: linear-gradient(top,  rgba(68,68,68,1) 0%,rgba(125,126,125,1) 100%);    
+    background: linear-gradient(top,  rgba(68,68,68,1) 0%,rgba(125,126,125,1) 100%);
 }
 
-.ui-tabs .ui-tabs-nav li a:hover {
+.ui-tabs-nav a:hover {
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,0.25)), color-stop(100%,rgba(255,255,255,0)));
     background: -webkit-linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
     background: linear-gradient(top,  rgba(255,255,255,0.25) 0%,rgba(255,255,255,0) 100%);
 }
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#currentRequesterTabLabel,
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#currentTabLabel {
-    background: rgb(241,231,103);    
+.ui-tabs-selected a#currentRequesterTabLabel,
+.ui-tabs-selected a#currentTabLabel {
+    background: rgb(241,231,103);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(241,231,103,1)), color-stop(100%,rgba(254,182,69,1)));
     background: -webkit-linear-gradient(top,  rgba(241,231,103,1) 0%,rgba(254,182,69,1) 100%);
     background: linear-gradient(top,  rgba(241,231,103,1) 0%,rgba(254,182,69,1) 100%);
 }
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#doneRequesterTabLabel,
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#doneTabLabel {
+.ui-tabs-selected a#doneRequesterTabLabel,
+.ui-tabs-selected a#doneTabLabel {
     background: rgb(198,226,113);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(198,226,113,1)), color-stop(100%,rgba(143,196,0,1)));
     background: -webkit-linear-gradient(top,  rgba(198,226,113,1) 0%,rgba(143,196,0,1) 100%);
     background: linear-gradient(top,  rgba(198,226,113,1) 0%,rgba(143,196,0,1) 100%);
 }
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#iceboxRequesterTabLabel,
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a#iceboxTabLabel {
+.ui-tabs-selected a#iceboxRequesterTabLabel,
+.ui-tabs-selected a#iceboxTabLabel {
     background: rgb(135,224,253);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(135,224,253,1)), color-stop(40%,rgba(83,203,241,1)), color-stop(100%,rgba(5,171,224,1)));
     background: -webkit-linear-gradient(top,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
     background: linear-gradient(top,  rgba(135,224,253,1) 0%,rgba(83,203,241,1) 40%,rgba(5,171,224,1) 100%);
 }
 
+.ui-tabs-selected a,
+.ui-tabs-nav .ui-state-disabled a,
+.ui-tabs-nav .ui-state-processing a {
+    cursor: text;
+}
 
-.ui-tabs .ui-tabs-nav li.ui-tabs-selected a, .ui-tabs .ui-tabs-nav li.ui-state-disabled a, .ui-tabs .ui-tabs-nav li.ui-state-processing a { cursor: text; }
-.ui-tabs .ui-tabs-nav li a, .ui-tabs.ui-tabs-collapsible .ui-tabs-nav li.ui-tabs-selected a { cursor: pointer; } /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
-.ui-tabs .ui-tabs-panel { display: block; border-width: 0; }
-.ui-tabs .ui-tabs-hide { display: none !important; }
+.ui-tabs-nav a,
+.ui-tabs-collapsible .ui-tabs-selected a {
+  cursor: pointer;
+} /* first selector in group seems obsolete, but required to overcome bug in Opera applying cursor: text overall if defined elsewhere... */
+
+.ui-tabs-panel { display: block; border-width: 0; }
+.ui-tabs-hide { display: none !important; }
 
 
 /* scrollbars */
 ::-webkit-scrollbar {
     width: 4px;
 }
- 
+
 ::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 6px rgba(0,0,0,0.3); 
+    box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
 }
- 
+
 ::-webkit-scrollbar-thumb {
-    background: rgba(0,0,0,0.4); 
-    box-shadow: inset 0 0 3px rgba(0,0,0,0.5); 
+    background: rgba(0,0,0,0.4);
+    box-shadow: inset 0 0 3px rgba(0,0,0,0.5);
 }
 
 ::-webkit-scrollbar-thumb:window-inactive {
-	background: rgba(0,0,0,0.4); 
+    background: rgba(0,0,0,0.4);
 }
 
 .powered {
@@ -259,7 +262,3 @@ body {
     width: 500px;
     margin: 0 auto 50px;
 }
-
-
-
-

--- a/stylesheets/library.css
+++ b/stylesheets/library.css
@@ -21,12 +21,12 @@
 
 /* links */
 a {
-	color: #135785;
-	text-decoration: none;
+    color: #135785;
+    text-decoration: none;
 }
 
 a:hover, a:active {
-	color: #c70000;
+    color: #c70000;
 }
 
 .inline {
@@ -99,7 +99,6 @@ p {
     background-color: #f2f2f2;
     border-left: 1px solid #aaa;
     box-shadow: 0 1px 7px rgba(0,0,0, 0.2) inset;
-    background: -moz-linear-gradient(top,  rgba(255,255,255,1) 0%, rgba(255,255,255,0.7) 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(255,255,255,1)), color-stop(100%,rgba(255,255,255,0.7)));
     background: -webkit-linear-gradient(top,  rgba(255,255,255,1) 0%,rgba(255,255,255,0.7) 100%);
     background: linear-gradient(top,  rgba(255,255,255,1) 0%,rgba(255,255,255,0.7) 100%);
@@ -108,7 +107,6 @@ p {
 .default-box {
     background-color: #f4f4f4;
     border: 1px solid #A5A5A5;
-/*     box-shadow: 0 2px 10px rgba(0,0,0, 0.2); */
 }
 
 .title {
@@ -122,7 +120,6 @@ p {
     border-bottom: 1px solid rgba(0,0,0, 0.4);
     color: #fff;
     background: rgb(181,186,191);
-    background: -moz-linear-gradient(top,  rgba(181,186,191,1) 0%, rgba(123,133,144,1) 100%);
     background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(181,186,191,1)), color-stop(100%,rgba(123,133,144,1)));
     background: -webkit-linear-gradient(top,  rgba(181,186,191,1) 0%,rgba(123,133,144,1) 100%);
     background: linear-gradient(top,  rgba(181,186,191,1) 0%,rgba(123,133,144,1) 100%);
@@ -637,7 +634,3 @@ Vasiliy saw and decided to leave it as is for now :) */
 .ui-sortable-helper {
     box-shadow: 0 0 5px rgba(0,0,0, 0.2);
 }
-
-
-
-


### PR DESCRIPTION
Made just a small cleanup.

Guys let's make a clean & easy to maintain CSS structure:
- Move to SASS
- Split library.css into small logical modules
- Create config with predefined variables & mixins (not to duplicate frequent stuff like colors, font-size, linear gradients)
- Compile & compress SASS into a single CSS bundle.

That would at least looks worthily & simplify contribution process for folks.
